### PR TITLE
Ticket4657 fix memory corruption, add tests and argument checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ O.*/
 doxygen/
 /bin/
 /lib/
+/test-reports/

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,13 @@ iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
 DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard iocs))
 iocs_DEPEND_DIRS += $(filter %App,$(DIRS))
 
+TEST_RUNNER = $(TOP)/pr4000App/src/O.$(EPICS_HOST_ARCH)/runner
+
 include $(TOP)/configure/RULES_TOP
 
+.PHONY: test
+test:
+ifneq ($(wildcard $(TEST_RUNNER)*),)
+	$(TEST_RUNNER) --gtest_output=xml:$(TOP)/test-reports/TEST-PR4000.xml
+endif
 

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -11,6 +11,7 @@ ONCRPC=$(SUPPORT)/oncrpc/master
 SNCSEQ=$(SUPPORT)/seq/master
 UTILITIES=$(SUPPORT)/utilities/master
 ASUBFUNCTIONS=$(SUPPORT)/asubFunctions/master
+GTEST=$(SUPPORT)/googletest/master
 
 include $(TOP)/../../../ISIS_CONFIG
 -include $(TOP)/../../../ISIS_CONFIG.$(EPICS_HOST_ARCH)

--- a/pr4000App/src/Makefile
+++ b/pr4000App/src/Makefile
@@ -20,4 +20,15 @@ pr4000_LIBS += $(EPICS_BASE_IOC_LIBS)
 
 pr4000_SRCS += units.c
 
+# googleTest Runner
+ifeq ($(findstring 10.0,$(VCVERSION)),)
+
+TESTPROD_HOST += runner
+USR_CPPFLAGS += -I$(GTEST)/googletest/include
+runner_SRCS += units.c units_tests.cpp run_all_tests.cc
+runner_LIBS += gtest
+runner_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+endif
+
 include $(TOP)/configure/RULES

--- a/pr4000App/src/run_all_tests.cc
+++ b/pr4000App/src/run_all_tests.cc
@@ -1,0 +1,6 @@
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest( &argc, argv );
+    return RUN_ALL_TESTS();
+    }

--- a/pr4000App/src/units.h
+++ b/pr4000App/src/units.h
@@ -1,0 +1,16 @@
+#ifndef UNITS_H
+#define UNITS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+extern long units_number_to_string(aSubRecord *prec);
+
+extern long units_string_to_number(aSubRecord *prec);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* UNITS_H */

--- a/pr4000App/src/units_tests.cc
+++ b/pr4000App/src/units_tests.cc
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+
+#include <epicsString.h>
+#include <aSubRecord.h>
+#include <menuFtype.h>
+
+#include "units.h"
+
+// in an asub function you should not reassign members of asubRecord,
+// however we are setting up an asubRecord here and so need to do so
+
+namespace {
+    TEST(Units, test_GIVEN_index_THEN_check_unit_returned){
+        // GIVEN
+        aSubRecord rec;
+
+        rec.fta = menuFtypeLONG;
+        rec.noa = 1;
+        rec.a = new epicsInt32[rec.noa];
+
+        rec.ftva = menuFtypeSTRING;
+        rec.nova = 1;
+        rec.vala = new epicsOldString[rec.nova];
+
+        // WHEN
+        *(epicsInt32*)rec.a = 1;
+        int ret = units_number_to_string(&rec);
+
+        // THEN
+        EXPECT_EQ(ret, 0);
+        EXPECT_STREQ(*(epicsOldString*)rec.vala, "mBar"); // or could make UNITS_ARRAY accessible and lookup directly
+
+        delete[] rec.a;
+        delete[] rec.vala;
+    }
+
+    TEST(Units, test_GIVEN_unit_THEN_check_index_returned){
+        // GIVEN
+        aSubRecord rec;
+
+        rec.fta = menuFtypeSTRING;
+        rec.noa = 1;
+        rec.a = new epicsOldString[rec.noa];
+
+        rec.ftva = menuFtypeLONG;
+        rec.nova = 1;
+        rec.vala = new epicsInt32[rec.nova];
+
+        // WHEN
+        strncpy(*(epicsOldString*)rec.a, "Torr", sizeof(epicsOldString));
+        int ret = units_string_to_number(&rec);
+
+        // THEN
+        EXPECT_EQ(ret, 0);
+        EXPECT_EQ(*(epicsInt32*)rec.vala, 4); // or could make UNITS_ARRAY accessible and lookup
+
+        delete[] rec.a;
+        delete[] rec.vala;
+    }
+} // namespace


### PR DESCRIPTION
* fix pointer assignment and usage with strings (caused memory corruption)
* fix use of long* rather than epicsInt32* (could cause issues on linux)
* add type checking of aSub arguments
* use case sensitive comparison (mBar and MBar both valid and not the same)
* make functions extern to allow testing in separate module
* Add google tests

See ISISComputingGroup/IBEX#4657
